### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Test
+permissions:
+  contents: read
+  id-token: write
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/XAI-liacs/BLADE/security/code-scanning/1](https://github.com/XAI-liacs/BLADE/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, the minimal permissions required are likely `contents: read` for accessing the repository contents and `id-token: write` for uploading coverage stats to Codecov. Additional permissions can be added if necessary.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
