### PR TITLE
Add token tracking and plotting

### DIFF
--- a/iohblade/__init__.py
+++ b/iohblade/__init__.py
@@ -9,6 +9,7 @@ from .plots import (
     plot_code_evolution_graphs,
     plot_convergence,
     plot_experiment_CEG,
+    plot_token_usage,
 )
 from .problem import Problem
 from .solution import Solution

--- a/iohblade/loggers/base.py
+++ b/iohblade/loggers/base.py
@@ -426,7 +426,7 @@ class RunLogger:
 
         return count >= self.budget
 
-    def log_conversation(self, role, content, cost=0.0):
+    def log_conversation(self, role, content, cost=0.0, tokens=0):
         """
         Logs the given conversation content into a conversation log file.
 
@@ -434,12 +434,14 @@ class RunLogger:
             role (str): Who (the llm or user) said the content.
             content (str): The conversation content to be logged.
             cost (float, optional): The cost of the conversation.
+            tokens (int, optional): Number of tokens used.
         """
         conversation_object = {
             "role": role,
             "time": f"{datetime.now()}",
             "content": content,
             "cost": float(cost),
+            "tokens": int(tokens),
         }
         with jsonlines.open(f"{self.dirname}/conversationlog.jsonl", "a") as file:
             file.write(conversation_object)

--- a/iohblade/loggers/mlflow.py
+++ b/iohblade/loggers/mlflow.py
@@ -158,7 +158,7 @@ class MLFlowRunLogger(RunLogger):
         # We do want to keep the parent's file-based logging directories
         super().__init__(name, root_dir, budget, progress_callback=progress_callback)
 
-    def log_conversation(self, role, content, cost=0.0):
+    def log_conversation(self, role, content, cost=0.0, tokens=0):
         """
         Logs conversation details to MLflow, plus calls super() to keep the local file logs if you wish.
         """
@@ -168,6 +168,7 @@ class MLFlowRunLogger(RunLogger):
             "time": str(datetime.now()),
             "content": content,
             "cost": float(cost),
+            "tokens": int(tokens),
         }
         # Example: We can log each conversation snippet as a text artifact
         mlflow.log_text(
@@ -177,7 +178,7 @@ class MLFlowRunLogger(RunLogger):
 
         # Also do the usual file-based logs or any other logic you have in the parent
         # (You may have to define such a method if you want to keep conversation logs in a file.)
-        super().log_conversation(role, content, cost)
+        super().log_conversation(role, content, cost, tokens)
 
     def log_individual(self, individual):
         """

--- a/iohblade/loggers/wandb.py
+++ b/iohblade/loggers/wandb.py
@@ -147,7 +147,7 @@ class WAndBRunLogger(RunLogger):
             progress_callback=progress_callback,
         )
 
-    def log_conversation(self, role, content, cost=0.0):
+    def log_conversation(self, role, content, cost=0.0, tokens=0):
         """
         Log conversation data to W&B plus the normal local file-based logs.
         """
@@ -156,12 +156,13 @@ class WAndBRunLogger(RunLogger):
             "time": str(datetime.now()),
             "content": content,
             "cost": float(cost),
+            "tokens": int(tokens),
         }
         # wandb.log can be repeated, but if content is large, consider an artifact
         wandb.log({"conversation": conversation})
 
         # Also do file-based logging
-        super().log_conversation(role, content, cost)
+        super().log_conversation(role, content, cost, tokens)
 
     def log_individual(self, individual: Solution):
         """

--- a/tests/test_behaviour_metrics.py
+++ b/tests/test_behaviour_metrics.py
@@ -111,8 +111,8 @@ class DummyLogger:
     def __init__(self):
         self.logged = []
 
-    def log_conversation(self, who, text, cost):
-        self.logged.append((who, text, cost))
+    def log_conversation(self, who, text, cost=0.0, tokens=0):
+        self.logged.append((who, text, cost, tokens))
 
 
 class DummyLLM(llm_mod.LLM):

--- a/tests/test_mlflowlogger.py
+++ b/tests/test_mlflowlogger.py
@@ -222,7 +222,9 @@ def test_run_logger_log_conversation(mock_run_logger, mock_mlflow):
     plus call the parent's file-based logs.
     """
     with patch("mlflow.log_text") as mock_log_text:
-        mock_run_logger.log_conversation(role="user", content="Hello MLFlow", cost=1.23)
+        mock_run_logger.log_conversation(
+            role="user", content="Hello MLFlow", cost=1.23, tokens=5
+        )
 
     # Check mlflow.log_text call
     mock_log_text.assert_called_once()
@@ -237,8 +239,10 @@ def test_run_logger_log_conversation(mock_run_logger, mock_mlflow):
     convo_path = os.path.join(mock_run_logger.dirname, "conversationlog.jsonl")
     assert os.path.exists(convo_path)
     with open(convo_path, "r") as f:
-        content = f.read()
-    assert "Hello MLFlow" in content
+        lines = [json.loads(l) for l in f]
+    assert any(
+        d.get("content") == "Hello MLFlow" and d.get("tokens") == 5 for d in lines
+    )
 
 
 def test_run_logger_log_individual(mock_run_logger, mock_mlflow):

--- a/tests/test_wandblogger.py
+++ b/tests/test_wandblogger.py
@@ -220,8 +220,12 @@ def test_run_logger_log_conversation(mock_run_logger, mock_wandb):
     """
     log_conversation() should record to local conversationlog.jsonl and also wandb.log().
     """
-    mock_run_logger.log_conversation(role="user", content="Hello AI", cost=0.5)
-    mock_run_logger.log_conversation(role="assistant", content="Hi, user!", cost=0.7)
+    mock_run_logger.log_conversation(
+        role="user", content="Hello AI", cost=0.5, tokens=2
+    )
+    mock_run_logger.log_conversation(
+        role="assistant", content="Hi, user!", cost=0.7, tokens=3
+    )
 
     # Check wandb calls
     # The wandb.log calls appear once per log_conversation call
@@ -235,9 +239,9 @@ def test_run_logger_log_conversation(mock_run_logger, mock_wandb):
     convo_file = os.path.join(mock_run_logger.dirname, "conversationlog.jsonl")
     assert os.path.exists(convo_file)
     with open(convo_file, "r") as f:
-        content = f.read()
-    assert "Hello AI" in content
-    assert "Hi, user!" in content
+        lines = [json.loads(l) for l in f]
+    assert any(d.get("content") == "Hello AI" and d.get("tokens") == 2 for d in lines)
+    assert any(d.get("content") == "Hi, user!" and d.get("tokens") == 3 for d in lines)
 
 
 def test_run_logger_log_code(mock_run_logger, mock_wandb):


### PR DESCRIPTION
## Summary
- record token counts in conversation logs
- log token info from LLM queries
- expose tokens in conversation loggers
- plot token usage per method and problem
- test new functionality

## Testing
- `uv run pytest --cov=iohblade --cov-report=xml tests/`

------
https://chatgpt.com/codex/tasks/task_e_686e1de8a718832187e6919c80159d2a