### PR TITLE
Add DeepSeek LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ BLADE supports integration with various LLM APIs to facilitate automated design 
 | **Gemini**   | Google's multimodal LLM designed to process text, images, audio, and more. [Reference](https://en.wikipedia.org/wiki/Gemini_%28language_model%29) | Accessible via the Gemini API, compatible with OpenAI libraries. [Reference](https://ai.google.dev/gemini-api/docs/openai) |
 | **OpenAI**   | Developer of GPT series models, including GPT-4, widely used for natural language understanding and generation. [Reference](https://openai.com/) | Integration through OpenAI's REST API and client libraries.                                                    |
 | **Ollama**   | A platform offering access to various LLMs, enabling local and cloud-based model deployment. [Reference](https://www.ollama.ai/) | Integration details can be found in their official documentation.                                             |
+| **DeepSeek** | Developer of the DeepSeek family of models for code and chat. [Reference](https://www.deepseek.com/) | Access via OpenAI compatible API at `https://api.deepseek.com`. |
 
 
 ### Evaluating against Human Designed baselines
@@ -103,7 +104,7 @@ It is the easiest to use BLADE from the pypi package (`iohblade`).
 ```
 > [!Important]
 > The Python version **must** be larger or equal to Python 3.11.
-> You need an OpenAI/Gemini/Ollama API key for using LLM models.
+> You need an OpenAI/Gemini/Ollama/DeepSeek API key for using LLM models.
 
 You can also install the package from source using <a href="https://docs.astral.sh/uv/" target="_blank">uv</a> (0.7.19).
 make sure you have `uv` installed.

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -9,7 +9,7 @@ It is easiest to use BLADE from the PyPI package:
 
 .. important::
    The Python version **must** be >= 3.11.
-   An OpenAI/Gemini/Ollama API key is needed for using LLM models.
+   An OpenAI/Gemini/Ollama/DeepSeek API key is needed for using LLM models.
 
 You can also install the package from source using **uv** (0.7.9).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,6 +128,9 @@ BLADE supports integration with various LLM APIs to facilitate automated design 
    * - **Ollama**
      - A platform offering access to various LLMs, enabling local and cloud-based model deployment. `Reference <https://www.ollama.ai/>`_
      - Integration details can be found in their official documentation.
+   * - **DeepSeek**
+     - Developer of the DeepSeek family of models for code and chat. `Reference <https://www.deepseek.com/>`_
+     - Access via OpenAI compatible API at ``https://api.deepseek.com``.
 
 Evaluating against Human Designed Baselines
 -------------------------------------------

--- a/iohblade/__init__.py
+++ b/iohblade/__init__.py
@@ -1,6 +1,13 @@
 import multiprocessing
 
-from .llm import LLM, Gemini_LLM, Ollama_LLM, OpenAI_LLM, Dummy_LLM
+from .llm import (
+    LLM,
+    Gemini_LLM,
+    Ollama_LLM,
+    OpenAI_LLM,
+    DeepSeek_LLM,
+    Dummy_LLM,
+)
 from .method import Method
 from .plots import (
     fitness_table,

--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -355,6 +355,17 @@ class OpenAI_LLM(LLM):
         return new
 
 
+class DeepSeek_LLM(OpenAI_LLM):
+    """A manager class for the DeepSeek chat models."""
+
+    def __init__(self, api_key, model="deepseek-chat", temperature=0.8, **kwargs):
+        """Initializes DeepSeek LLM with required base URL."""
+        super().__init__(api_key, model=model, temperature=temperature, **kwargs)
+        self.base_url = "https://api.deepseek.com"
+        self._client_kwargs["base_url"] = self.base_url
+        self.client = openai.OpenAI(**self._client_kwargs)
+
+
 class Gemini_LLM(LLM):
     """
     A manager class for handling requests to Google's Gemini models.


### PR DESCRIPTION
## Summary
- add `DeepSeek_LLM` for DeepSeek chat API
- export the class in `__init__.py`
- test `DeepSeek_LLM` basic construction
- document DeepSeek in README and docs
- mention required DeepSeek API key in installation docs

## Testing
- `black --check iohblade/llm.py iohblade/__init__.py tests/test_llm.py`
- `pytest tests/test_llm.py::test_deepseek_llm_init` *(fails: ModuleNotFoundError: No module named 'lizard')*

------
https://chatgpt.com/codex/tasks/task_e_6889fcb22700832188c0a2c721795cc2