### PR TITLE
Add conversation log viewer to BLADE webapp

### DIFF
--- a/iohblade/webapp.py
+++ b/iohblade/webapp.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import matplotlib
 import pandas as pd
 import plotly.graph_objects as go
+import plotly.express as px
 import jsonlines
 import streamlit as st
+import urllib
 
 from iohblade.plots import CEG_FEATURES, CEG_FEATURE_LABELS, plotly_code_evolution
 
@@ -37,41 +39,74 @@ def convergence_dataframe(logger: ExperimentLogger) -> pd.DataFrame:
     return df
 
 
+# helper: convert '#RRGGBB' or 'rgb(r,g,b)' to rgba with alpha
+def _rgba(color: str, alpha: float) -> str:
+    # handles '#rrggbb'
+    if color.startswith("#") and len(color) == 7:
+        r = int(color[1:3], 16)
+        g = int(color[3:5], 16)
+        b = int(color[5:7], 16)
+        return f"rgba({r},{g},{b},{alpha})"
+    # handles 'rgb(r,g,b)'
+    if color.startswith("rgb(") and color.endswith(")"):
+        nums = color[4:-1]
+        return f"rgba({nums},{alpha})"
+    # fallback: let Plotly parse; many qualitative colors are hex so this usually won’t hit
+    return color
+
+
 def plotly_convergence(df: pd.DataFrame, aggregate: bool = False) -> go.Figure:
     fig = go.Figure()
+    palette = px.colors.qualitative.Plotly  # or px.colors.qualitative.D3
+
     if aggregate:
-        for (m, p), g in df.groupby(["method_name", "problem_name"]):
+        for i, ((m, p), g) in enumerate(df.groupby(["method_name", "problem_name"])):
             summary = (
                 g.groupby("eval")["cummax_fitness"].agg(["mean", "std"]).reset_index()
             )
-            fig.add_trace(
-                go.Scatter(
-                    x=summary["eval"],
-                    y=summary["mean"],
-                    mode="lines",
-                    name=f"{m}-{p}",
-                )
-            )
-            fig.add_trace(
-                go.Scatter(
-                    x=summary["eval"],
-                    y=summary["mean"] + summary["std"],
-                    mode="lines",
-                    line=dict(width=0),
-                    showlegend=False,
-                )
-            )
+            color = palette[i % len(palette)]
+            group = f"{m}-{p}"
+
+            # Draw LOWER bound first
             fig.add_trace(
                 go.Scatter(
                     x=summary["eval"],
                     y=summary["mean"] - summary["std"],
                     mode="lines",
-                    line=dict(width=0),
-                    fill="tonexty",
+                    line=dict(width=0, color=color),
+                    hoverinfo="skip",
                     showlegend=False,
+                    legendgroup=group,
+                    name=group,  # not shown because showlegend=False
+                )
+            )
+            # Then UPPER bound, fill to previous (lower)
+            fig.add_trace(
+                go.Scatter(
+                    x=summary["eval"],
+                    y=summary["mean"] + summary["std"],
+                    mode="lines",
+                    line=dict(width=0, color=color),
+                    fill="tonexty",
+                    fillcolor=_rgba(color, 0.18),  # match line color, add alpha
+                    hoverinfo="skip",
+                    showlegend=False,
+                    legendgroup=group,
+                )
+            )
+            # Finally the MEAN line on top
+            fig.add_trace(
+                go.Scatter(
+                    x=summary["eval"],
+                    y=summary["mean"],
+                    mode="lines",
+                    line=dict(color=color),
+                    name=group,
+                    legendgroup=group,
                 )
             )
     else:
+        # per-seed lines (no bands)
         for (m, p, s), g in df.groupby(["method_name", "problem_name", "seed"]):
             fig.add_trace(
                 go.Scatter(
@@ -81,7 +116,14 @@ def plotly_convergence(df: pd.DataFrame, aggregate: bool = False) -> go.Figure:
                     name=f"{m}-{p}-seed{s}",
                 )
             )
-    fig.update_layout(xaxis_title="Evaluations", yaxis_title="Best fitness")
+
+    fig.update_layout(
+        xaxis_title="Evaluations",
+        yaxis_title="Best fitness",
+        legend=dict(
+            groupclick="togglegroup"
+        ),  # click one legend item toggles its whole group
+    )
     return fig
 
 
@@ -102,6 +144,7 @@ def discover_experiments(root=RESULTS_DIR):
 
 
 def read_progress(exp_dir):
+    """Read the progress of an experiment from the directory"""
     path = os.path.join(exp_dir, "progress.json")
     if os.path.exists(path):
         with open(path) as f:
@@ -127,11 +170,13 @@ def run() -> None:
                 for msg in f:
                     role = msg.get("role", "assistant")
                     content = msg.get("content", "")
-                    chat_role = "user" if role.lower() in {"client", "user"} else "assistant"
+                    chat_role = (
+                        "user" if role.lower() in {"client", "user"} else "assistant"
+                    )
                     with st.chat_message(chat_role):
                         st.markdown(content)
         else:
-            st.write("No conversation log found.")
+            st.write(f"No conversation log found in {log_path}.")
         return
 
     if "last_refresh" not in st.session_state:
@@ -140,14 +185,11 @@ def run() -> None:
         st.session_state["last_refresh"] = time.time()
         st.rerun()
 
-    logo_html = f"""
-    <picture>
-      <source media='(prefers-color-scheme: dark)' srcset='{LOGO_DARK}'>
-      <source media='(prefers-color-scheme: light)' srcset='{LOGO_LIGHT}'>
-      <img src='{LOGO_LIGHT}' style='width: 150px;'>
-    </picture>
-    """
-    st.sidebar.markdown(logo_html, unsafe_allow_html=True)
+    with st.sidebar:
+        st.image(
+            LOGO_LIGHT if st.context.theme.type == "light" else LOGO_DARK,
+            width=150,
+        )
     st.sidebar.markdown("### Experiments")
 
     experiments = discover_experiments()
@@ -194,20 +236,6 @@ def run() -> None:
                     pct_run = evaluations / budget if budget else 0
                     st.progress(pct_run, text=label)
 
-        if prog and prog.get("runs"):
-            st.markdown("#### Run Logs")
-            for r in prog["runs"]:
-                label = f"{r['method_name']} | {r['problem_name']} | seed {r['seed']}"
-                log_dir = r.get("log_dir")
-                if log_dir:
-                    conv_path = os.path.join(exp_dir, log_dir, "conversationlog.jsonl")
-                    if os.path.exists(conv_path):
-                        link = f"?exp={selected}&conv={log_dir}"
-                        st.markdown(
-                            f"- {label} - <a href='{link}' target='_blank'>Conversation Log</a>",
-                            unsafe_allow_html=True,
-                        )
-
         st.header(f"Convergence - {selected}")
         df = convergence_dataframe(logger)
         if not df.empty:
@@ -223,11 +251,11 @@ def run() -> None:
             fig = plotly_convergence(df_filt, aggregate=aggregate)
             st.plotly_chart(fig, use_container_width=True)
 
-            final_df = (
-                df_filt.groupby(["method_name", "problem_name", "seed"])
-                .last()
-                .reset_index()
-            )
+            final_df = df_filt.loc[
+                df_filt.groupby(["method_name", "problem_name", "seed"])[
+                    "cummax_fitness"
+                ].idxmax()
+            ].reset_index(drop=True)
             box_fig = go.Figure()
             for prob in problem_sel:
                 subset = final_df[final_df["problem_name"] == prob]
@@ -289,8 +317,29 @@ def run() -> None:
                             mime="text/x-python",
                             key=f"download_{m}_{sol.get('id', 'id')}",
                         )
+
+            st.markdown("#### Run Logs")
+            for m in method_sel:
+                m_runs = runs[runs["method_name"] == m].sort_values(by=["seed"])
+                with st.expander(m):
+                    for _, r in m_runs.iterrows():
+                        label = f"{r['method_name']} | {r['problem_name']} | seed {r['seed']}"
+                        log_dir = r.get("log_dir")
+                        if log_dir:
+                            conv_path = os.path.join(
+                                exp_dir, log_dir, "conversationlog.jsonl"
+                            )
+                            if os.path.exists(conv_path):
+                                selected_url = urllib.parse.quote_plus(selected)
+                                log_dir_url = urllib.parse.quote_plus(log_dir)
+                                link = f"?exp={selected_url}&conv={log_dir_url}"
+                                st.markdown(
+                                    f"- {label} - <a href='{link}' target='_blank'>Conversation Log</a>",
+                                    unsafe_allow_html=True,
+                                )
         else:
             st.write("No data")
+
     else:
         st.write("Select an experiment from the sidebar to view results.")
 


### PR DESCRIPTION
## Summary
- Allow viewing conversation logs in a separate chat-style window with Markdown and code highlighting.
- Add links to open conversation logs for each run in experiments.
- Fixed the convergence plot to have matching colors for shaded area and lines.
- Fixed the boxplots to show best fitness distribution instead of last fitness distribution.

