### PR TITLE
chore: drop Gemini system instruction

### DIFF
--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -394,7 +394,6 @@ class Gemini_LLM(LLM):
                 "top_k": 64,
                 "max_output_tokens": 65536,
                 "response_mime_type": "text/plain",
-                "system_instruction": "You are a computer scientist and excellent Python programmer.",
             }
 
         self.client = genai.Client(api_key=api_key)


### PR DESCRIPTION
## Summary
- remove system instruction usage from Gemini LLM wrapper

## Testing
- `black --check iohblade/llm.py`
- `isort --check-only --profile=black -v iohblade/llm.py`
- `pytest -q` *(fails: ModuleNotFoundError: ioh, cloudpickle, httpx, mlflow, matplotlib, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b029b832ec832192d384af213c48ab