### PR TITLE
Feature/kwargs for query

### DIFF
--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -139,7 +139,9 @@ class LLM(ABC):
         self.logger = logger
         self.log = True
 
-    def sample_solution(self, session_messages: list, parent_ids=[], HPO=False, **kwargs):
+    def sample_solution(
+        self, session_messages: list, parent_ids=[], HPO=False, **kwargs
+    ):
         """
         Interacts with a language model to generate or mutate solutions based on the provided session messages.
 
@@ -289,7 +291,9 @@ class OpenAI_LLM(LLM):
         logging.getLogger("httpx").setLevel(logging.ERROR)
         self.temperature = temperature
 
-    def _query(self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs):
+    def _query(
+        self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs
+    ):
         """
         Sends a conversation history to the configured model and returns the response text.
 
@@ -317,7 +321,7 @@ class OpenAI_LLM(LLM):
                     model=self.model,
                     messages=session_messages,
                     temperature=temperature,
-                    **kwargs
+                    **kwargs,
                 )
                 return response.choices[0].message.content
 
@@ -411,7 +415,9 @@ class Gemini_LLM(LLM):
         self.client = genai.Client(api_key=api_key)
         self.generation_config = generation_config
 
-    def _query(self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs):
+    def _query(
+        self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs
+    ):
         """
         Sends the conversation history to Gemini, retrying on 429 ResourceExhausted exceptions.
 
@@ -469,7 +475,9 @@ class Ollama_LLM(LLM):
         """
         super().__init__("", model, None, **kwargs)
 
-    def _query(self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs):
+    def _query(
+        self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs
+    ):
         """
         Sends a conversation history to the configured model and returns the response text.
 
@@ -495,7 +503,7 @@ class Ollama_LLM(LLM):
                 response = ollama.chat(
                     model=self.model,
                     messages=[{"role": "user", "content": big_message}],
-                    options=kwargs
+                    options=kwargs,
                 )
                 return response["message"]["content"]
 

--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -307,10 +307,16 @@ class OpenAI_LLM(LLM):
         attempt = 0
         while True:
             try:
+                ## Manage temeperature copy.
+                temperature = self.temperature
+                if "temperature" in kwargs:
+                    temperature = kwargs["temperature"]
+                    kwargs.pop("temperature")
+
                 response = self.client.chat.completions.create(
                     model=self.model,
                     messages=session_messages,
-                    temperature=self.temperature,
+                    temperature=temperature,
                     **kwargs
                 )
                 return response.choices[0].message.content

--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -428,7 +428,7 @@ class Gemini_LLM(LLM):
         while True:
             try:
                 config = self.generation_config.copy()
-                config = config.update(**kwargs)
+                config.update(**kwargs)
                 chat = self.client.chats.create(
                     model=self.model, history=history, config=config
                 )

--- a/iohblade/llm.py
+++ b/iohblade/llm.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 from abc import ABC, abstractmethod
+from typing import Any
 
 import anthropic
 import ollama
@@ -287,13 +288,14 @@ class OpenAI_LLM(LLM):
         logging.getLogger("httpx").setLevel(logging.ERROR)
         self.temperature = temperature
 
-    def _query(self, session_messages, max_retries: int = 5, default_delay: int = 10):
+    def _query(self, session_messages, max_retries: int = 5, default_delay: int = 10, **kwargs):
         """
         Sends a conversation history to the configured model and returns the response text.
 
         Args:
             session_messages (list of dict): A list of message dictionaries with keys
                 "role" (e.g. "user", "assistant") and "content" (the message text).
+            **kwargs
 
         Returns:
             str: The text content of the LLM's response.
@@ -306,6 +308,7 @@ class OpenAI_LLM(LLM):
                     model=self.model,
                     messages=session_messages,
                     temperature=self.temperature,
+                    **kwargs
                 )
                 return response.choices[0].message.content
 
@@ -599,7 +602,7 @@ class Dummy_LLM(LLM):
         for msg in session_messages:
             big_message += msg["content"] + "\n"
         response = """This is a dummy response from the DUMMY LLM. It does not connect to any LLM provider.
-It is used for testing purposes only. 
+It is used for testing purposes only.
 # Description: A simple random search algorithm that samples points uniformly in the search space and returns the best found solution.
 # Code:
 ```python
@@ -615,12 +618,10 @@ class RandomSearch:
     def __call__(self, func):
         for i in range(self.budget):
             x = np.random.uniform(func.bounds.lb, func.bounds.ub)
-            
             f = func(x)
             if f < self.f_opt:
                 self.f_opt = f
                 self.x_opt = x
-            
         return self.f_opt, self.x_opt
 ```
 # Configuration Space:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -373,7 +373,7 @@ def test_dummy_llm():
     assert llm.model == "dummy-model"
     response = llm._query([{"role": "user", "content": "test"}])
     assert (
-        len(response) == 946
-    ), "Dummy_LLM should return a 946-character string, returned length: {}".format(
+        len(response) == 919
+    ), "Dummy_LLM should return a 919-character string, returned length: {}".format(
         len(response)
     )


### PR DESCRIPTION
Added feature to run query with custom parameters like temperature, top_k, top_n, etc. on a per call basis.
Added test cases, for all Ollama, OpenAI, Gemini _query and sample_solution for passing kwargs.