### PR TITLE
Add diff chain visualization for code evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ After running experiments you can browse them using the built-in Streamlit app:
 uv run iohblade-webapp
 ```
 
-The app lists available experiments from the `results` directory, displays their progress, and shows convergence plots.
+The app lists available experiments from the `results` directory, displays
+their progress, shows convergence plots, and lets you inspect code evolution
+graphs with annotated diff chains.
 
 ---
 

--- a/iohblade/webapp.py
+++ b/iohblade/webapp.py
@@ -2,20 +2,24 @@ import json
 import os
 import subprocess
 import time
+import urllib
 from pathlib import Path
 
+import jsonlines
 import matplotlib
 import pandas as pd
-import plotly.graph_objects as go
 import plotly.express as px
-import jsonlines
+import plotly.graph_objects as go
 import streamlit as st
-import urllib
-
-from iohblade.plots import CEG_FEATURES, CEG_FEATURE_LABELS, plotly_code_evolution
 
 from iohblade.assets import LOGO_DARK_B64, LOGO_LIGHT_B64
 from iohblade.loggers import ExperimentLogger
+from iohblade.plots import (
+    CEG_FEATURE_LABELS,
+    CEG_FEATURES,
+    code_diff_chain,
+    plotly_code_evolution,
+)
 
 LOGO_LIGHT = f"data:image/png;base64,{LOGO_LIGHT_B64}"
 LOGO_DARK = f"data:image/png;base64,{LOGO_DARK_B64}"
@@ -292,6 +296,14 @@ def run() -> None:
                     st.plotly_chart(ceg_fig, use_container_width=True)
                 else:
                     st.write("No data for selected run.")
+
+            if not run_df.empty:
+                sol_id = st.selectbox(
+                    "Solution for diff chain", run_df["id"], key="diff_solution"
+                )
+                if st.button("Show Code Diff Chain", key="show_diff_chain"):
+                    diff = code_diff_chain(run_df, sol_id)
+                    st.code(diff, language="diff")
 
             st.markdown("#### Top Solutions")
             runs = logger.get_data()


### PR DESCRIPTION
## Summary
- add `code_diff_chain` to build annotated diffs along a solution's ancestry
- expose diff chain viewer in the web app and document it
- cover diff chain with dedicated unit test

## Testing
- `uv run pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68b747ddfca0832198dcdb7910765db6