### PR TITLE
Add hooks for customizing run setup

### DIFF
--- a/iohblade/loggers/base.py
+++ b/iohblade/loggers/base.py
@@ -90,6 +90,21 @@ class ExperimentLogger:
         os.mkdir(dirname)
         return dirname
 
+    def _before_open_run(self, run_name, method, problem, budget, seed):
+        """Hook executed before a run is opened."""
+        return None
+
+    def _create_run_logger(self, run_name, budget, progress_cb):
+        """Create and return the run logger for a run."""
+        from .base import RunLogger
+
+        return RunLogger(
+            name=run_name,
+            root_dir=self.dirname,
+            budget=budget,
+            progress_callback=progress_cb,
+        )
+
     def open_run(self, method, problem, budget=100, seed=0):
         """
         Opens (starts) a new run for logging.
@@ -97,14 +112,11 @@ class ExperimentLogger:
         """
         run_name = f"{method.name}-{problem.name}-{seed}"
 
+        self._before_open_run(run_name, method, problem, budget, seed)
+
         progress_cb = partial(self.increment_eval, method.name, problem.name, seed)
 
-        self.run_logger = RunLogger(
-            name=run_name,
-            root_dir=self.dirname,
-            budget=budget,
-            progress_callback=progress_cb,
-        )
+        self.run_logger = self._create_run_logger(run_name, budget, progress_cb)
         problem.set_logger(self.run_logger)
         with self._lock:
             entry = self._get_run_entry(method.name, problem.name, seed)


### PR DESCRIPTION
## Summary
- introduce `_before_open_run` hook and `_create_run_logger` factory in `ExperimentLogger`
- call new hooks from `open_run` to prepare and instantiate run loggers

## Testing
- `uv run isort iohblade/loggers/base.py`
- `uv run black iohblade/loggers/base.py`
- `uv run pytest tests/` *(fails: ModuleNotFoundError: No module named 'ioh', 'cloudpickle', 'httpx', 'matplotlib', 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b8ab0712e083218eec120e76aa5f0a