### PR TITLE
Refactor MLflow run opening to use base hooks

### DIFF
--- a/tests/test_mlflowlogger.py
+++ b/tests/test_mlflowlogger.py
@@ -1,20 +1,11 @@
 import json
 import os
-import sys
-from datetime import datetime
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
+import mlflow
 import pytest
 
-sys.modules.setdefault("mlflow", MagicMock())
-sys.modules.setdefault("mlflow.exceptions", MagicMock())
-sys.modules.setdefault("mlflow.pyfunc", MagicMock())
-import mlflow
-
 from iohblade.llm import LLM
-
-# Adjust these imports to your actual package structure
-from iohblade.loggers import ExperimentLogger, RunLogger
 from iohblade.loggers.mlflow import MLFlowExperimentLogger, MLFlowRunLogger
 from iohblade.method import Method
 from iohblade.problem import Problem


### PR DESCRIPTION
## Summary
- Start MLflow runs in `_before_open_run` and track active run state
- Create `MLFlowRunLogger` via `_create_run_logger`
- Delegate `open_run` to parent implementation for shared progress tracking
- Remove MagicMock module stubs in MLflow tests and rely on real dependencies

## Testing
- `uv run pytest tests/test_mlflowlogger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b854f8148321ac68566c956c7b62