### PR TITLE
Initialize Trackio per thread for parallel runs

### DIFF
--- a/tests/test_trackio_logger.py
+++ b/tests/test_trackio_logger.py
@@ -21,7 +21,7 @@ def mock_trackio():
         yield mock_module
 
 
-def test_experiment_logger_open_run(tmp_path, mock_trackio):
+def test_run_logger_start_and_finish(tmp_path, mock_trackio):
     class DummyMethod(Method):
         def __call__(self, problem):
             pass
@@ -42,13 +42,20 @@ def test_experiment_logger_open_run(tmp_path, mock_trackio):
         def to_dict(self):
             return {"type": "DummyProblem"}
 
+    class DummyLLM(LLM):
+        def _query(self, *args, **kwargs):
+            return ""
+
     dm = DummyMethod(None, budget=10, name="MyMethod")
     dp = DummyProblem(name="MyProblem")
+    llm = DummyLLM(api_key="", model="gpt")
     logger = TrackioExperimentLogger(name=str(tmp_path / "exp"))
-    logger.open_run(dm, dp, 1)
+    run_logger = logger.open_run(dm, dp, 1, seed=0)
+    run_logger.start_run(llm)
+    run_logger.finish_run(Solution(name="sol"))
 
     mock_trackio.init.assert_called_once()
-    assert logger._run_active
+    mock_trackio.finish.assert_called_once()
 
 
 def test_experiment_logger_add_run(tmp_path, mock_trackio):
@@ -86,18 +93,27 @@ def test_experiment_logger_add_run(tmp_path, mock_trackio):
     logger = TrackioExperimentLogger(name=str(tmp_path / "exp"))
     logger.add_run(method, problem, llm, solution, log_dir="fake", seed=42)
 
-    mock_trackio.log.assert_called()
-    mock_trackio.finish.assert_called_once()
+    mock_trackio.log.assert_not_called()
+    mock_trackio.finish.assert_not_called()
 
     exp_log_path = os.path.join(logger.dirname, "experimentlog.jsonl")
     assert os.path.isfile(exp_log_path)
 
 
 def test_run_logger_log_conversation(tmp_path, mock_trackio):
-    run_logger = TrackioRunLogger(name="test_run", root_dir=str(tmp_path), budget=5)
+    run_logger = TrackioRunLogger(
+        name="test_run",
+        root_dir=str(tmp_path),
+        budget=5,
+        project="proj",
+        method_name="m",
+        problem_name="p",
+        seed=0,
+    )
     run_logger.log_conversation("user", "Hello Trackio", cost=1.0, tokens=5)
 
-    mock_trackio.log.assert_called_once()
+    mock_trackio.init.assert_called_once()
+    mock_trackio.log.assert_called()
     convo_path = os.path.join(run_logger.dirname, "conversationlog.jsonl")
     assert os.path.exists(convo_path)
     with open(convo_path, "r") as f:
@@ -106,11 +122,20 @@ def test_run_logger_log_conversation(tmp_path, mock_trackio):
 
 
 def test_run_logger_log_individual(tmp_path, mock_trackio):
-    run_logger = TrackioRunLogger(name="test_run", root_dir=str(tmp_path), budget=5)
+    run_logger = TrackioRunLogger(
+        name="test_run",
+        root_dir=str(tmp_path),
+        budget=5,
+        project="proj",
+        method_name="m",
+        problem_name="p",
+        seed=0,
+    )
     sol = Solution(name="test_solution")
     sol.set_scores(3.14)
     run_logger.log_individual(sol)
 
+    mock_trackio.init.assert_called_once()
     assert mock_trackio.log.call_count >= 1
     log_path = os.path.join(run_logger.dirname, "log.jsonl")
     assert os.path.exists(log_path)


### PR DESCRIPTION
## Summary
- defer Trackio initialization to run threads and add explicit `start_run`/`finish_run`
- call run logger hooks in experiment runner to manage Trackio sessions
- update Trackio tests for new lifecycle

## Testing
- `uv run --no-sync pytest tests/` *(fails: ModuleNotFoundError: No module named 'cloudpickle')*


------
https://chatgpt.com/codex/tasks/task_e_68b945fc62888321abbea04f71c9953d