### PR TITLE
Add wrap_problem helper for simple custom problems

### DIFF
--- a/iohblade/__init__.py
+++ b/iohblade/__init__.py
@@ -4,7 +4,7 @@ import multiprocessing
 # dependencies.  Modules such as ``llm`` or ``plots`` require optional
 # third-party packages and should be imported explicitly by consumers
 # that need them.
-from .problem import Problem
+from .problem import Problem, wrap_problem
 from .solution import Solution
 from .utils import (
     NoCodeException,
@@ -19,6 +19,7 @@ from .utils import (
 
 __all__ = [
     "Problem",
+    "wrap_problem",
     "Solution",
     "NoCodeException",
     "OverBudgetException",

--- a/tests/test_wrap_problem.py
+++ b/tests/test_wrap_problem.py
@@ -1,0 +1,28 @@
+from iohblade import Solution, wrap_problem
+
+
+def dummy_eval(problem, solution):
+    solution.set_scores(1.23, "ok")
+    return solution
+
+
+def test_wrap_problem_creates_instance():
+    p = wrap_problem(
+        dummy_eval,
+        name="Wrapped",
+        eval_timeout=5,
+        training_instances=[1],
+        test_instances=[2],
+        dependencies=["numpy"],
+        imports="import numpy as np",
+        task_prompt="Do task",
+        example_prompt="Example code",
+    )
+    s = Solution()
+    res = p.evaluate(s)
+    assert res.fitness == 1.23
+    assert p.name == "Wrapped"
+    assert p.task_prompt == "Do task"
+    assert p.example_prompt == "Example code"
+    d = p.to_dict()
+    assert d["name"] == "Wrapped"


### PR DESCRIPTION
## Summary
- add `wrap_problem` function to build `Problem` instances from plain evaluate functions
- re-export `wrap_problem` at package level
- test wrapped problems can evaluate solutions

## Testing
- `uv run pytest tests/test_wrap_problem.py`
- `uv run pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68b977b61a8083218457357188963a67