### PR TITLE
Cache pip dependencies in e2e workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -25,6 +25,12 @@ jobs:
           # Install a specific version of uv.
           version: "0.7.19"
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------


### PR DESCRIPTION
## Summary
- cache pip downloads in e2e test workflow to speed up repeated runs

## Testing
- `uv sync --dev`
- `uv run pytest tests/` *(fails: hangs at tests/e2e/test_completeflow.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d7c8c4c8321a4f5c9cf942c692c