### PR TITLE
Handle cross-platform paths in experiment loggers

### DIFF
--- a/iohblade/loggers/base.py
+++ b/iohblade/loggers/base.py
@@ -172,7 +172,10 @@ class ExperimentLogger:
             log_dir (str): The directory where the run is logged.
             seed (int): The seed used in the run.
         """
-        rel_log_dir = os.path.relpath(log_dir, self.dirname)
+        try:
+            rel_log_dir = os.path.relpath(log_dir, self.dirname)
+        except ValueError:
+            rel_log_dir = log_dir
         run_object = {
             "method_name": method.name,
             "problem_name": problem.name,

--- a/iohblade/loggers/mlflow.py
+++ b/iohblade/loggers/mlflow.py
@@ -2,7 +2,6 @@ import json
 import os
 from datetime import datetime
 
-
 import pandas as pd
 from ConfigSpace.read_and_write import json as cs_json
 
@@ -114,7 +113,10 @@ class MLFlowExperimentLogger(ExperimentLogger):
         mlflow.log_metric("final_fitness", final_fitness)
 
         # Log a serialized object as an artifact
-        rel_log_dir = os.path.relpath(log_dir, self.dirname)
+        try:
+            rel_log_dir = os.path.relpath(log_dir, self.dirname)
+        except ValueError:
+            rel_log_dir = log_dir
         run_object = {
             "method_name": method.name,
             "problem_name": problem.name,

--- a/tests/unit/test_loggers.py
+++ b/tests/unit/test_loggers.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -60,11 +61,11 @@ def test_experiment_logger_add_run(cleanup_tmp_dir):
     # Check the log file
     log_file = os.path.join(exp_logger.dirname, "experimentlog.jsonl")
     with open(log_file, "r") as f:
-        contents = f.read()
-    assert "dummy_method" in contents
+        entry = json.loads(f.readline())
+    assert entry["method_name"] == "dummy_method"
     expected_rel = os.path.relpath("dummy_dir", exp_logger.dirname)
-    assert expected_rel in contents
-    assert '"seed": 42' in contents
+    assert entry["log_dir"] == expected_rel
+    assert entry["seed"] == 42
 
 
 def test_run_logger_log_individual(cleanup_tmp_dir):


### PR DESCRIPTION
## Summary
- avoid ValueError when computing relative log paths on different drives
- read experiment log JSON in tests to ensure cross-platform path comparisons

## Testing
- `uv run pytest tests/unit/test_loggers.py::test_experiment_logger_add_run tests/unit/test_mlflowlogger.py::test_experiment_logger_add_run -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2eea0724832192c53959d953f78f