### PR TITLE
Update docs Pages workflow to publish on releases with latest-tag default

### DIFF
--- a/.github/workflows/docs2pages.yml
+++ b/.github/workflows/docs2pages.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -54,7 +56,24 @@ jobs:
       run: uv sync --dev --group docs --no-group apple-silicon
     - name: Build documentation
       run: |
-        uv run sphinx-build -b html docs/ ./_site      
+        uv run sphinx-multiversion docs/ ./_site
+
+    - name: Select default docs version for site root
+      shell: bash
+      run: |
+        set -euo pipefail
+        latest_tag_dir="$(find ./_site -maxdepth 1 -mindepth 1 -type d -name 'v*' | sort -V | tail -n 1 || true)"
+
+        if [[ -n "${latest_tag_dir}" ]]; then
+          echo "Using latest released docs as default: ${latest_tag_dir}"
+          cp -a "${latest_tag_dir}/." ./_site/
+        elif [[ -d ./_site/main ]]; then
+          echo "No release tags found; falling back to main docs for root index"
+          cp -a ./_site/main/. ./_site/
+        else
+          echo "No eligible docs directory found to publish at site root" >&2
+          exit 1
+        fi
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
 

--- a/docs/_templates/sidebar/scroll-end.html
+++ b/docs/_templates/sidebar/scroll-end.html
@@ -1,0 +1,22 @@
+{%- set _versions = versions | default([]) -%}
+{%- set _current = current_version | default({'name': version}) -%}
+
+{%- if _versions %}
+<div class="sidebar-tree">
+  <p class="caption" role="heading">
+    <span class="caption-text">Version</span>
+  </p>
+  <label for="version-selector" class="visually-hidden">Version</label>
+  <select
+    id="version-selector"
+    onchange="if (this.value) window.location.href = this.value;"
+    style="width: 100%;"
+  >
+    {%- for item in _versions %}
+    <option value="{{ item.url }}" {% if item.name == _current.name %}selected{% endif %}>
+      {{ item.name }}
+    </option>
+    {%- endfor %}
+  </select>
+</div>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "myst_parser",
     "nbsphinx",
     "sphinx_copybutton",
+    "sphinx_multiversion",
 ]
 
 nbsphinx_allow_errors = True  # Continue through errors in notebook cells
@@ -46,6 +47,12 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 autodoc_mock_imports = ["modcma"]
+
+# sphinx-multiversion configuration
+smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
+smv_branch_whitelist = r"^main$"
+smv_released_pattern = r"^refs/tags/v\d+\.\d+\.\d+$"
+smv_outputdir_format = "{ref.name}"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ docs = [
     "furo>=2024.8.6,<2025",
     "sphinxext-opengraph>=0.9.1,<0.10",
     "sphinx-copybutton>=0.5.2,<0.6",
+    "sphinx-multiversion>=0.2.4,<0.3",
 ]
 methods = [
     "eoh",

--- a/uv.lock
+++ b/uv.lock
@@ -2071,6 +2071,7 @@ docs = [
     { name = "pandoc" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
+    { name = "sphinx-multiversion" },
     { name = "sphinx-rtd-theme" },
     { name = "sphinxext-opengraph" },
 ]
@@ -2139,6 +2140,7 @@ docs = [
     { name = "pandoc", specifier = "~=2.4" },
     { name = "sphinx", specifier = "==7.4.7" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<0.6" },
+    { name = "sphinx-multiversion", specifier = ">=0.2.4,<0.3" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<4" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1,<0.10" },
 ]
@@ -5757,6 +5759,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinx-multiversion"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/10/25231164a97a9016bdc73a3530af8f4a6846bdc564af1460af2ff3e59a50/sphinx-multiversion-0.2.4.tar.gz", hash = "sha256:5cd1ca9ecb5eed63cb8d6ce5e9c438ca13af4fa98e7eb6f376be541dd4990bcb", size = 7024, upload-time = "2020-08-12T15:48:20.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/51/203bb30b3ce76373237288e92cb71fb66f80ee380473f36bfe8a9d299c5d/sphinx_multiversion-0.2.4-py2.py3-none-any.whl", hash = "sha256:5c38d5ce785a335d8c8d768b46509bd66bfb9c6252b93b700ca8c05317f207d6", size = 9597, upload-time = "2024-10-03T21:45:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ad/4989e6be165805694e93d09bc57425aa1368273b7de4fe3083fe4310803a/sphinx_multiversion-0.2.4-py3-none-any.whl", hash = "sha256:dec29f2a5890ad68157a790112edc0eb63140e70f9df0a363743c6258fbeb478", size = 9642, upload-time = "2020-08-12T15:48:19.649Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I implemented (partly using codex) the multi-version documentation we spoke off. 
This will help a lot in keeping track of features and releases.

## Summary
- Updated `.github/workflows/docs2pages.yml` triggers to run on both:
  - pushes to `main` (to keep the `main` docs variant fresh), and
  - published GitHub releases (to publish on release events).
- Kept `sphinx-multiversion` as the docs build command.
- Replaced root publishing behavior:
  - instead of always copying `main` to `_site/`, the workflow now selects the highest `v*` version folder (semantic version sort) as the site root default,
  - and only falls back to `_site/main` when no release-tag folders are present.

## Behavior after this change
- `main/` docs are still generated and updated.
- The default landing page (`/index.html`) now points to the latest released tag docs when available.
- New release publication triggers docs deployment immediately.
