### PR TITLE
Fix version selector redirect to include /BLADE/ base path

### DIFF
--- a/docs/_templates/sidebar/scroll-start.html
+++ b/docs/_templates/sidebar/scroll-start.html
@@ -11,23 +11,11 @@
   <select
     id="version-selector"
     style="width: 100%;"
-    onchange="
-      if (!this.value) return;
-      const target = this.value;
-      if (/^https?:\/\//.test(target)) {
-        window.location.href = target;
-      } else if (target.startsWith('{{ _docs_base }}/')) {
-        window.location.href = target;
-      } else if (target.startsWith('/')) {
-        window.location.href = '{{ _docs_base }}' + target;
-      } else {
-        window.location.href = '{{ _docs_base }}/' + target;
-      }
-    "
+    onchange="if (this.value) window.location.href = this.value;"
   >
     {%- for item in _versions %}
     <option
-      value="{{ item.url }}"
+      value="{{ _docs_base }}/{{ item.name }}/index.html"
       {% if item.name == _current.name %}selected{% endif %}
     >
       {{ item.name }}


### PR DESCRIPTION
The option values used item.url, which sphinx-multiversion sets as a
page-relative path (e.g. ../v0.9.0/index.html). Prepending /BLADE/ to
that produced /BLADE/../v0.9.0/index.html, which resolves to the wrong
/v0.9.0/index.html. Now each option value is built directly from the
version name as /BLADE/{version}/index.html.

https://claude.ai/code/session_013SbaxCHBpeNtWNSrbQC7if